### PR TITLE
fix: extend not_var regexp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,23 @@
 
 name: Release Package to npm
 
-# This workflow is configured in package.json publishConfig
-# It publishes the package to npm when a release is created
+# This workflow handles both stable and prerelease publishing to npm
+# - Stable: triggered by release event or manual dispatch with 'stable' type
+# - Prerelease: triggered by manual dispatch with 'prerelease' type (only from non-protected branches)
 
 on:
   release:
     types: [published]
-  workflow_dispatch: # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+          - prerelease
+          - stable
 
 permissions:
   contents: read
@@ -21,6 +31,11 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    # For prerelease - only from non-protected branches
+    if: |
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable') ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease' && github.ref_protected != true)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,6 +65,7 @@ jobs:
       - name: Build package
         run: npm run build
 
+      # === STABLE RELEASE STEPS ===
       - name: Check version matches release tag
         if: github.event_name == 'release'
         run: |
@@ -68,8 +84,19 @@ jobs:
           echo "Skipping publish for draft release"
           exit 0
 
-      - name: Publish to npm
-        if: github.event.release.draft == false || github.event_name == 'workflow_dispatch'
+      - name: Publish stable to npm
+        if: (github.event_name == 'release' && github.event.release.draft == false) || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # === PRERELEASE STEPS ===
+      - name: Set prerelease version
+        if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease'
+        run: npm version --no-git-tag-version 0.0.0-rc-$(git branch --show-current)-${{github.run_id}}
+
+      - name: Publish prerelease to npm
+        if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease'
+        run: npm publish --tag $(git branch --show-current) --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -23,14 +23,14 @@ if echo "$SUBJECT" | grep -qE '^(fixup!|squash!)'; then
 fi
 
 # Check Conventional Commits format: <type>(<scope>): <subject>
-# Types: feat, fix, perf, refactor, docs, chore, revert
+# Types: feat, fix, perf, refactor, docs, chore, revert, deps
 # Scope is optional
-if ! echo "$SUBJECT" | grep -qE '^(feat|fix|perf|refactor|docs|chore|revert)(\([^)]+\))?: .+'; then
+if ! echo "$SUBJECT" | grep -qE '^(feat|fix|perf|refactor|docs|chore|revert|deps)(\([^)]+\))?: .+'; then
     echo "❌ Error: Commit message does not follow Conventional Commits format."
     echo ""
     echo "Expected format: <type>(<scope>): <subject>"
     echo ""
-    echo "Types: feat, fix, perf, refactor, docs, chore, revert"
+    echo "Types: feat, fix, perf, refactor, docs, chore, revert, deps"
     echo "Scope is optional"
     echo ""
     echo "Examples:"

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -37,20 +37,19 @@ module.exports = {
         if (filtered.length === 0) {
             return [];
         }
+
         return [
-            ...filtered.map((f) => `prettier --write ${f}`),
-            ...filtered.map(
-                (f) => `env ESLINT_USE_FLAT_CONFIG=false npx eslint --max-warnings=0 --fix ${f}`,
-            ),
+            `prettier --write ${filtered.join(' ')}`,
+            `env ESLINT_USE_FLAT_CONFIG=false npx eslint --max-warnings=0 --fix`,
         ];
     },
     // Handle .lintstagedrc.js separately (only prettier, no eslint)
     '.lintstagedrc.js': (filenames) => filenames.map((f) => `prettier --write ${f}`),
     '**/*.{css,scss}': (filenames) => [
-        ...filenames.map((f) => `prettier --write ${f}`),
-        ...filenames.map((f) => `stylelint --fix ${f}`),
+        `prettier --write ${filenames.join(' ')}`,
+        `stylelint --fix ${filenames.join(' ')}`,
     ],
-    '**/*.{json,yaml,yml,md}': (filenames) => filenames.map((f) => `prettier --write ${f}`),
+    '**/*.{json,yaml,yml,md}': (filenames) => `prettier --write ${filenames.join(' ')}`,
     '**/*.{svg,svgx}': ['svgo'],
     // Run unit tests when test files or source files change
     '**/*.{ts,tsx}': (filenames) => {

--- a/src/syntax/lexical.ts
+++ b/src/syntax/lexical.ts
@@ -5,8 +5,25 @@ const doubleQuoted = /"[^"]*"/;
 const quoted = new RegExp(`${singleQuoted.source}|${doubleQuoted.source}`);
 export const quoteBalanced = new RegExp(`(?:${quoted.source}|[^'"])*`);
 
-export const vars = /((not_var)?({{2}([. \w-|(),]+)}{2}))/gm;
-export const singleVariable = /^{{2}([. \w-|(),]+)}{2}$/;
+// Jinja2 expression content:
+// \w          - identifiers (letters, digits, underscore)
+// .           - attribute access
+// \-          - hyphen in names, negative numbers
+// |           - filters
+// ()          - function calls
+// ,           - argument separator
+// '"          - string literals
+// =           - named parameters
+// []          - indexing, subscript
+// :           - slices, dict literals
+// +*/%        - arithmetic operators
+// <>!         - comparison operators
+// ~           - Jinja string concatenation
+// @           - decorators (rare)
+// \s already handled by space in character class
+const varsContent = /[.\w\-|(),'=":[\]+*/%<>!~@\s]+/;
+export const vars = new RegExp(`((not_var)?({{2}(${varsContent.source})}{2}))`, 'gm');
+export const singleVariable = new RegExp(`^{{2}(${varsContent.source})}{2}$`);
 
 // basic types
 const number = /-?\d+\.?\d*|\.?\d+/;

--- a/test/lexical.test.ts
+++ b/test/lexical.test.ts
@@ -51,5 +51,91 @@ describe('Lexical functions', () => {
         test('Unmatched curly braces should return false', () => {
             expect(isSingleVariable('{{variable}')).toEqual(false);
         });
+
+        // Function calls with parameters
+        test('Function call with single param', () => {
+            expect(isSingleVariable('{{ do_something(1) }}')).toEqual(true);
+        });
+
+        test('Function call with multiple params', () => {
+            expect(isSingleVariable("{{ do_something(2, 'explicit value', 200) }}")).toEqual(true);
+        });
+
+        test('Function call with named param', () => {
+            expect(isSingleVariable('{{ do_something(3, param_3=300) }}')).toEqual(true);
+        });
+
+        test('Function call without params', () => {
+            expect(isSingleVariable('{{ do_something_without_params() }}')).toEqual(true);
+        });
+
+        // Function calls with not_var prefix
+        test('Function call with not_var prefix should return false', () => {
+            expect(isSingleVariable('not_var{{ do_something(1) }}')).toEqual(false);
+        });
+
+        test('Function call without params with not_var prefix should return false', () => {
+            expect(isSingleVariable('not_var{{ do_something_without_params() }}')).toEqual(false);
+        });
+
+        // Function calls with comments
+        test('Function call followed by comment should return false', () => {
+            expect(
+                isSingleVariable(
+                    "not_var{{ do_something(1) }} {#- do_something(1, 'default value', none) -#}",
+                ),
+            ).toEqual(false);
+        });
+
+        test('Function call with params followed by comment should return false', () => {
+            expect(
+                isSingleVariable(
+                    "{{ do_something(2, 'explicit value', 200) }} {#- do_something(1, 'explicit value', 100) -#}",
+                ),
+            ).toEqual(false);
+        });
+
+        test('Function call with named param followed by comment should return false', () => {
+            expect(
+                isSingleVariable(
+                    "{{ do_something(3, param_3=300) }} {#- do_something(1, 'default value', 300) -#}",
+                ),
+            ).toEqual(false);
+        });
+
+        // Macro definitions
+        test('Macro definition with default params should return false', () => {
+            expect(
+                isSingleVariable(
+                    "{%- macro do_something(param_1, param_2='default value', param_3=none) -%}",
+                ),
+            ).toEqual(false);
+        });
+
+        test('Macro definition without params should return false', () => {
+            expect(isSingleVariable('{%- macro do_something_without_params() -%}')).toEqual(false);
+        });
+
+        test('Macro endmacro tag should return false', () => {
+            expect(isSingleVariable('{%- endmacro -%}')).toEqual(false);
+        });
+
+        test('Full macro block should return false', () => {
+            expect(
+                isSingleVariable(`{%- macro do_something(param_1, param_2='default value', param_3=none) -%}
+    {# body of macro here #}
+{%- endmacro -%}`),
+            ).toEqual(false);
+        });
+
+        test('Comment only should return false', () => {
+            expect(isSingleVariable('{# body of macro here #}')).toEqual(false);
+        });
+
+        test('Trimmed comment should return false', () => {
+            expect(isSingleVariable("{#- do_something(1, 'default value', none) -#}")).toEqual(
+                false,
+            );
+        });
     });
 });


### PR DESCRIPTION
add symbols for
```js
// Jinja2 expression content:
// \w          - identifiers (letters, digits, underscore)
// .           - attribute access
// \-          - hyphen in names, negative numbers
// |           - filters
// ()          - function calls
// ,           - argument separator
// '"          - string literals
// =           - named parameters
// []          - indexing, subscript
// :           - slices, dict literals
// +*/%        - arithmetic operators
// <>!         - comparison operators
// ~           - Jinja string concatenation
// @           - decorators (rare)
// \s already handled by space in character class
```